### PR TITLE
Bug correction when external layers and external background are set

### DIFF
--- a/external_ows_layers.py
+++ b/external_ows_layers.py
@@ -139,14 +139,17 @@ class ExternalOwsLayers:
 
         wms_layers = []
         layer_opacities = []
+        
+        nb_external_layers = len(re.findall("EXTERNAL_WMS:",",".join(layers)))
+        
         for i, layer in enumerate(layers):
             m = wms_layer_pattern.match(layer)
             if m is not None:
                 # external WMS layer
                 # generate name for external layer (A, B, C, ..., AA, BB, ...)
-                name = chr(97 + i % 26).upper()
-                if i > 26:
-                    name *= (i // 26) + 1
+                name = chr(97 + ( i + nb_external_layers ) % 26).upper()
+                if ( i + nb_external_layers ) > 26:
+                    name *= ((i + nb_external_layers) // 26) + 1
 
                 base_url = self.url_with_suffix(m.group(1))
                 layers = m.group(2)

--- a/server.py
+++ b/server.py
@@ -99,7 +99,7 @@ class Print(Resource):
         # Search layers parameter
         layerparam = None
         for key, value in params.items():
-            if key.endswith(":LAYERS"):
+            if key.startswith("MAP") and key.endswith(":LAYERS"):
                 layerparam = key
                 break
         if not layerparam:


### PR DESCRIPTION
Hi and happy new year,

This PR fix a bug when  external layers and external background are set together : 

- In **server.py**, 'layerparam' is not set correctly, it take 'A:LAYERS' when an external layer is set.
- In **external_ows_layers.py** we need to know how many externals layers are defined to affect the good letter name for the external background layer (A,B,C,...)

Benoit Ducarouge from Oslandia.